### PR TITLE
xformers 0.0.30 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,14 +32,14 @@ source:
     folder: third_party/flash-attention
 
 build:
-  number: 0
+  number: 1
   # Only supports Linux x86_64 for the CUDA variant (matches vllm's xformers pin:
   # `xformers==0.0.30; platform_system == 'Linux' and platform_machine == 'x86_64'`).
   # CPU variant is buildable on linux-64/linux-aarch64/osx-arm64. No Windows support.
   # py3.13+ skipped until xformers upstream publishes CPython extension wheels.
   skip: true  # [py<310 or py>312 or win or (cpu_or_cuda == "cuda" and not (linux and x86_64))]
-  string: cpu_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}   # [cpu_or_cuda == "cpu"]
-  string: cuda_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cpu_or_cuda == "cuda"]
+  string: cpu_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}   # [cpu_or_cuda == "cpu"]
+  string: cuda_py{{ CONDA_PY }}h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cpu_or_cuda == "cuda"]
   # Pass cpu_or_cuda (the variant key) directly into the build env so build.sh
   # can branch on it without needing to second-guess cuda_compiler_version. The
   # `script_env: cuda_compiler_version=None  # [cpu_or_cuda == "cpu"]` override


### PR DESCRIPTION
xformers 0.0.30 rebuild

**Destination channel:** defaults

### Links

- [PKG-14050](https://anaconda.atlassian.net/browse/PKG-14050) 
- [Upstream repository](https://github.com/facebookresearch/xformers)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- Build string fix enabling releases for all python versions. Without this, build strings from builds with different versions of python clash, and not all packages are released.


[PKG-14050]: https://anaconda.atlassian.net/browse/PKG-14050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ